### PR TITLE
Only shellcheck scripts with .sh extension

### DIFF
--- a/scripts/build_and_test.sh
+++ b/scripts/build_and_test.sh
@@ -32,7 +32,7 @@ main() {
   os="$(uname -s)"
 
   install_dependencies "$1"  
-  shellcheck scripts/*
+  shellcheck scripts/*.sh
 
   local ncpu
   ncpu="$(nproc)"


### PR DESCRIPTION
We were also shellchecking python scripts.

## Summary by Sourcery

Configures shellcheck to only check shell scripts with the .sh extension.