### PR TITLE
Fix the infinite loop problem with CTRL-T

### DIFF
--- a/linenoise.cpp
+++ b/linenoise.cpp
@@ -1514,8 +1514,8 @@ const char *linenoiseEditFeed(struct linenoiseState *l) {
 
             std::string prev_char(prev_chlen, 0);
             memcpy(prev_char.data(), l->buf+l->pos-prev_chlen, prev_chlen);
-            memcpy(l->buf+l->pos-prev_chlen, l->buf+l->pos, curr_chlen);
-            memcpy(l->buf+l->pos-prev_chlen+curr_chlen, prev_char.data(), prev_chlen);
+            memmove(l->buf+l->pos-prev_chlen, l->buf+l->pos, curr_chlen);
+            memmove(l->buf+l->pos-prev_chlen+curr_chlen, prev_char.data(), prev_chlen);
 
             if (l->pos+curr_chlen != l->len) l->pos += curr_chlen;
 

--- a/linenoise.cpp
+++ b/linenoise.cpp
@@ -1509,10 +1509,16 @@ const char *linenoiseEditFeed(struct linenoiseState *l) {
         break;
     case CTRL_T:    /* ctrl-t, swaps current character with previous. */
         if (l->pos > 0 && l->pos < l->len) {
-            int aux = l->buf[l->pos-1];
-            l->buf[l->pos-1] = l->buf[l->pos];
-            l->buf[l->pos] = aux;
-            if (l->pos != l->len-1) l->pos++;
+            auto prev_chlen = prevCharLen(l->buf,l->len,l->pos,NULL);
+            auto curr_chlen = nextCharLen(l->buf,l->len,l->pos,NULL);
+
+            std::string prev_char(prev_chlen, 0);
+            memcpy(prev_char.data(), l->buf+l->pos-prev_chlen, prev_chlen);
+            memcpy(l->buf+l->pos-prev_chlen, l->buf+l->pos, curr_chlen);
+            memcpy(l->buf+l->pos-prev_chlen+curr_chlen, prev_char.data(), prev_chlen);
+
+            if (l->pos+curr_chlen != l->len) l->pos += curr_chlen;
+
             refreshLine(l);
         }
         break;


### PR DESCRIPTION
Fix the problem reported at https://github.com/rain-1/linenoise-mob/issues/34 in a better way.

## Summary by Sourcery

Fixes an issue where using CTRL-T could result in an infinite loop. The fix swaps the current character with the previous one, taking into account UTF-8 character lengths to avoid issues with multi-byte characters.

Bug Fixes:
- Fixes a bug where CTRL-T could cause an infinite loop when used to swap characters.
- Fixes an issue with CTRL-T that did not correctly handle UTF-8 characters.