### PR TITLE
Fix performance problem with isWideChar and isCombiningChar

### DIFF
--- a/linenoise.cpp
+++ b/linenoise.cpp
@@ -311,8 +311,7 @@ static const size_t wideCharTableSize =
     sizeof(wideCharTable) / sizeof(wideCharTable[0]);
 
 static int isWideChar(unsigned long cp) {
-    size_t i;
-    for (i = 0; i < wideCharTableSize; i++) {
+    for (size_t i = 0; i < wideCharTableSize; i++) {
         auto first_code = wideCharTable[i][0];
         auto last_code = wideCharTable[i][1];
         if (first_code > cp) return 0;
@@ -584,8 +583,7 @@ static const unsigned long combiningCharTableSize =
     sizeof(combiningCharTable) / sizeof(combiningCharTable[0]);
 
 static int isCombiningChar(unsigned long cp) {
-    size_t i;
-    for (i = 0; i < combiningCharTableSize; i++) {
+    for (size_t i = 0; i < combiningCharTableSize; i++) {
         auto code = combiningCharTable[i];
         if (code > cp) return 0;
         if (code == cp) return 1;

--- a/linenoise.cpp
+++ b/linenoise.cpp
@@ -312,8 +312,12 @@ static const size_t wideCharTableSize =
 
 static int isWideChar(unsigned long cp) {
     size_t i;
-    for (i = 0; i < wideCharTableSize; i++)
-        if (wideCharTable[i][0] <= cp && cp <= wideCharTable[i][1]) return 1;
+    for (i = 0; i < wideCharTableSize; i++) {
+        auto first_code = wideCharTable[i][0];
+        auto last_code = wideCharTable[i][1];
+        if (first_code > cp) return 0;
+        if (first_code <= cp && cp <= last_code) return 1;
+    }
     return 0;
 }
 
@@ -581,8 +585,11 @@ static const unsigned long combiningCharTableSize =
 
 static int isCombiningChar(unsigned long cp) {
     size_t i;
-    for (i = 0; i < combiningCharTableSize; i++)
-        if (combiningCharTable[i] == cp) return 1;
+    for (i = 0; i < combiningCharTableSize; i++) {
+        auto code = combiningCharTable[i];
+        if (code > cp) return 0;
+        if (code == cp) return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Made the same fix at https://github.com/rain-1/linenoise-mob/pull/32 to improve the single-line mode performance problem.

## Summary by Sourcery

Enhancements:
- Improves performance of `isWideChar` and `isCombiningChar` functions.