### PR TITLE
Fix problem with swapping an Emoji (4 bytes) and an ASCII code (1 byte).

### DIFF
--- a/linenoise.cpp
+++ b/linenoise.cpp
@@ -1522,7 +1522,8 @@ const char *linenoiseEditFeed(struct linenoiseState *l) {
             memmove(l->buf+l->pos-prev_chlen, l->buf+l->pos, curr_chlen);
             memmove(l->buf+l->pos-prev_chlen+curr_chlen, prev_char.data(), prev_chlen);
 
-            if (l->pos+curr_chlen != l->len) l->pos += curr_chlen;
+            l->pos = l->pos - prev_chlen + curr_chlen;
+            if (l->pos + prev_chlen != l->len) l->pos += curr_chlen;
 
             refreshLine(l);
         }


### PR DESCRIPTION
This is a follow up to #7. This pull request fixes a problem when swapping an Emoji (4 bytes in UTF8) and an ASCII code (1 byte).

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where swapping an Emoji (4 bytes) and an ASCII code (1 byte) resulted in incorrect cursor positioning.