### PR TITLE
Fix CTRL_T problem with "a😀b" (Follow up to #12)

### DIFF
--- a/linenoise.cpp
+++ b/linenoise.cpp
@@ -1535,7 +1535,7 @@ static void handleCtrlTKey(struct linenoiseState * l) {
 
         l->pos = l->pos - prev_chlen + curr_chlen;
         if (l->pos + prev_chlen != l->len) {
-            l->pos += curr_chlen;
+            l->pos += prev_chlen;
         }
 
         refreshLine(l);


### PR DESCRIPTION
This is a follow up to #12. #12 actually isn't enough to fix a problem like swapping 'a' and '😀' in "a😀b" which causes the infinite loop. Hope it clears all the remaining problems related to the CTRL_T operation. Thanks!

## Summary by Sourcery

Bug Fixes:
- Fixes an infinite loop caused by swapping multi-byte and single-byte characters with Ctrl+T.