### PR TITLE
add bzlmod support

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,10 @@
+cc_library(
+  name = "linenoise-cpp",
+  hdrs = [
+    "linenoise.h"
+  ],
+  srcs = [
+    "linenoise.cpp",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,5 @@
+"linenoise"
+
+module(name='linenoise.cpp', version = "0.1.0")
+
+bazel_dep(name = "rules_cc", version = "0.1.1")


### PR DESCRIPTION
## Summary by Sourcery

Introduce bzlmod support by adding a MODULE.bazel file and a BUILD file for the linenoise-cpp library.

Build:
- Add MODULE.bazel file to enable bzlmod support.
- Add BUILD file for the linenoise-cpp library.