### PR TITLE
Reworked meson file to reuse/install the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 linenoise_example
 *.dSYM
 history.txt
+/build/

--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,33 @@ project('linenoise.cpp', 'cpp',
         'cpp_std=c++17'
   ])
 
-executable('linenoise',
-  'example.cpp',
-  'linenoise.cpp'
+linenoise_lib = library(
+    'linenoise',
+    [
+      'linenoise.cpp',
+    ],
+    cpp_args: [],
+    install: true,
+    dependencies: [],
+    include_directories: [include_directories('.')],
 )
 
+linenoise_dep = declare_dependency(
+  link_with: linenoise_lib,
+  include_directories: [include_directories('.')],
+)
+
+executable('linenoise',
+  'example.cpp',
+  dependencies: [linenoise_dep]
+)
+
+install_headers(['linenoise.h'])
+
+pconf = import('pkgconfig')
+pconf.generate(
+  linenoise_lib,
+  description: 'A minimal, zero-config, BSD licensed, readline replacement ',
+  url: 'https://github.com/ericcurtin/linenoise.cpp',
+  version: meson.project_version(),
+)


### PR DESCRIPTION
Added functioning meson file to install or include the library in other projects. Fix for part of https://github.com/ericcurtin/linenoise.cpp/issues/18.  
I don't use cmake so I don't feel comfortable writing that myself.

## Summary by Sourcery

Refactor Meson build setup to produce an installable library and pkg-config file, and allow other projects to include linenoise.cpp via Meson dependency

Enhancements:
- Define a reusable Meson library target for linenoise.cpp
- Update example target to link against the declared library dependency
- Install public header and generate pkg-config metadata during build