### PR TITLE
Fix CVE-2025-9810

### DIFF
--- a/linenoise.cpp
+++ b/linenoise.cpp
@@ -2050,7 +2050,7 @@ int linenoiseHistorySave(const char * filename) {
     if (file.file == NULL) {
         return -1;
     }
-    chmod(filename, S_IRUSR | S_IWUSR);
+    fchmod(fileno(file.file), S_IRUSR|S_IWUSR);
     for (int j = 0; j < history_len; ++j) {
         fprintf(file.file, "%s\n", history[j]);
     }


### PR DESCRIPTION
Please see https://github.com/antirez/linenoise/pull/240

## Summary by Sourcery

Bug Fixes:
- Ensure the history file is created with user-only read/write permissions by using fchmod on the opened file descriptor instead of chmod on the filename.